### PR TITLE
手動停止時の履歴表示の改善

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -65,8 +65,21 @@ export async function stopTaskLogic(activeTask, isManualStop = false) {
         return null;
     }
 
-    const taskToSave = { ...activeTask, endTime: Date.now(), isManualStop: isManualStop };
+    const now = Date.now();
+    // 通常の作業中の場合は、その作業を正常終了させる
+    const taskToSave = { ...activeTask, endTime: now, isManualStop: false };
     await dbPut(STORE_LOGS, taskToSave);
+
+    if (isManualStop) {
+        // 停止ボタンが押された場合は、追加で停止マーカーを記録する
+        const stopLog = {
+            category: SYSTEM_CATEGORY_IDLE,
+            startTime: now,
+            endTime: now,
+            isManualStop: true
+        };
+        await dbAdd(STORE_LOGS, stopLog);
+    }
     return null;
 }
 

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -75,13 +75,20 @@ describe('Logic Module', () => {
             expect(dbAdd).not.toHaveBeenCalled();
         });
 
-        test('stopTaskLogic stops active task', async () => {
+        test('stopTaskLogic stops active task and adds stop marker if manual', async () => {
             const activeTask = { id: 1, category: 'Work', startTime: Date.now() };
             const result = await stopTaskLogic(activeTask, true);
             expect(result).toBeNull();
+            // Original task should be completed with isManualStop: false
             expect(dbPut).toHaveBeenCalledWith(STORE_LOGS, expect.objectContaining({
                 id: 1,
                 category: 'Work',
+                endTime: expect.any(Number),
+                isManualStop: false
+            }));
+            // A new stop marker should be added
+            expect(dbAdd).toHaveBeenCalledWith(STORE_LOGS, expect.objectContaining({
+                category: SYSTEM_CATEGORY_IDLE,
                 endTime: expect.any(Number),
                 isManualStop: true
             }));


### PR DESCRIPTION
手動停止時に履歴から作業カテゴリが消えてしまう不具合を修正しました。
実行中の作業を正常に完了させた後、別途「終了」マーカーを記録することで、
どの作業をいつ終了したかが履歴に正しく残るようになりました。

---
*PR created automatically by Jules for task [13281347634251986018](https://jules.google.com/task/13281347634251986018) started by @masanori-satake*