### PR TITLE
待機中の終了操作による記録消失の修正

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -59,12 +59,14 @@ export async function startTaskLogic(categoryName, activeTask, resumableCategory
 export async function stopTaskLogic(activeTask, isManualStop = false) {
     if (!activeTask) return null;
 
+    const now = Date.now();
+
     if (activeTask.isPaused) {
         const idleLog = {
             ...activeTask,
             category: SYSTEM_CATEGORY_IDLE,
-            endTime: Date.now(),
-            isManualStop: isManualStop
+            endTime: now,
+            isManualStop: false
         };
         delete idleLog.isPaused;
 
@@ -75,13 +77,11 @@ export async function stopTaskLogic(activeTask, isManualStop = false) {
         }
 
         await dbDelete(STORE_SETTINGS, SETTING_KEY_PAUSE_STATE);
-        return null;
+    } else {
+        // 通常の作業中の場合は、その作業を正常終了させる
+        const taskToSave = { ...activeTask, endTime: now, isManualStop: false };
+        await dbPut(STORE_LOGS, taskToSave);
     }
-
-    const now = Date.now();
-    // 通常の作業中の場合は、その作業を正常終了させる
-    const taskToSave = { ...activeTask, endTime: now, isManualStop: false };
-    await dbPut(STORE_LOGS, taskToSave);
 
     if (isManualStop) {
         // 停止ボタンが押された場合は、追加で停止マーカーを記録する

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -120,6 +120,25 @@ describe('Logic Module', () => {
             expect(dbDelete).toHaveBeenCalledWith(STORE_SETTINGS, SETTING_KEY_PAUSE_STATE);
         });
 
+        test('stopTaskLogic handles manual stop during pause state by adding separate marker', async () => {
+            const pauseState = { id: 2, category: SYSTEM_CATEGORY_IDLE, startTime: Date.now(), resumableCategory: 'Work', isPaused: true };
+            const result = await stopTaskLogic(pauseState, true);
+            expect(result).toBeNull();
+            // The idle log should be completed normally
+            expect(dbPut).toHaveBeenCalledWith(STORE_LOGS, expect.objectContaining({
+                id: 2,
+                category: SYSTEM_CATEGORY_IDLE,
+                endTime: expect.any(Number),
+                isManualStop: false
+            }));
+            // A separate manual stop marker should be added
+            expect(dbAdd).toHaveBeenCalledWith(STORE_LOGS, expect.objectContaining({
+                category: SYSTEM_CATEGORY_IDLE,
+                isManualStop: true
+            }));
+            expect(dbDelete).toHaveBeenCalledWith(STORE_SETTINGS, SETTING_KEY_PAUSE_STATE);
+        });
+
         test('pauseTaskLogic transitions to pause state and adds to logs', async () => {
             const activeTask = { id: 1, category: 'Work', startTime: Date.now() };
             const newTask = await pauseTaskLogic(activeTask);


### PR DESCRIPTION
待機状態（一時停止中）で作業を終了した際、待機記録のログエントリーが終了マーカーとして上書きされてしまい、履歴から消失して見える問題を修正しました。

`stopTaskLogic` において、一時停止中の手動終了時に待機ログを正常終了させ、別途終了マーカーを追加するように変更することで、待機時間の記録が正しく履歴に残るようになります。

Fixes #29

---
*PR created automatically by Jules for task [3724327466414243512](https://jules.google.com/task/3724327466414243512) started by @masanori-satake*