### PR TITLE
Add timeouts to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v4
@@ -26,6 +27,7 @@ jobs:
 
     - name: Install dependencies
       run: npm install
+      timeout-minutes: 5
 
     - name: Check version consistency
       run: python3 scripts/check_version.py
@@ -41,9 +43,11 @@ jobs:
 
     - name: Install Playwright Browsers
       run: npx playwright install chromium --with-deps
+      timeout-minutes: 5
 
     - name: Start local server
       run: python3 -m http.server 8080 &
 
     - name: Run E2E tests
       run: npm run test:e2e
+      timeout-minutes: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Implemented timeouts for GitHub Actions workflows as requested. This ensures that workflows will fail quickly if they hang, saving runner usage and providing faster feedback.

Key changes:
- In `.github/workflows/ci.yml`:
    - Added `timeout-minutes: 15` to the `test` job.
    - Added `timeout-minutes: 5` to `Install dependencies` and `Install Playwright Browsers`.
    - Added `timeout-minutes: 10` to `Run E2E tests`.
- In `.github/workflows/deploy.yml`:
    - Added `timeout-minutes: 10` to the `deploy` job.

Fixes #55

---
*PR created automatically by Jules for task [7443045725723245375](https://jules.google.com/task/7443045725723245375) started by @masanori-satake*