### PR TITLE
Clarify Animation Worker Architecture and Thread Safety in Documentation

### DIFF
--- a/docs/animation_module_spec.md
+++ b/docs/animation_module_spec.md
@@ -34,12 +34,11 @@ sequenceDiagram
     participant U_Inst as ユーザー
     participant C_Inst as QuickLog 本体 (Core)
     participant W_Inst as Animation Worker (Thread)
-    participant M_Inst as アニメーションモジュール (Instance)
 
     U_Inst->>C_Inst: 業務カテゴリを選択
     C_Inst->>C_Inst: タイマー計測開始
     C_Inst->>W_Inst: init (modulePath) を postMessage
-    create participant M_Inst
+    create participant M_Inst as アニメーションモジュール (Instance)
     W_Inst->>M_Inst: new モジュールクラス()
     W_Inst-->>C_Inst: initialized 通知
     C_Inst->>W_Inst: setup(width, height) を postMessage


### PR DESCRIPTION
This submission updates the animation module specification to accurately reflect the multi-threaded architecture of QuickLog-Solo. 

Key changes:
1. **Sequence Diagrams**: The "Initialization", "Viewport Resize", and "Termination" diagrams now explicitly show the `Animation Worker` as an intermediary between the `QuickLog Core` and the `Animation Module`. This aligns the documentation with the actual implementation where all animation logic runs within a Web Worker.
2. **Race Condition Clarification**: Added a new section under "Safety and Security Policy" that explains why race conditions (e.g., `setup` and `draw` overlapping) are impossible. It clarifies that Web Workers process messages sequentially in a single-threaded event loop, providing inherent thread safety for animation modules.
3. **Mermaid Consistency**: Ensured unique participant IDs (e.g., `W_Inst`, `W_Size`, `W_Term`) across all diagrams to prevent rendering issues in GitHub's rich display.

These changes address the user's concerns about potential race conditions and clarify the system's internal design for future developers.

---
*PR created automatically by Jules for task [11579893177800102621](https://jules.google.com/task/11579893177800102621) started by @masanori-satake*