### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
       - 'LICENSE'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/masanori-satake/QuickLog-Solo/security/code-scanning/3](https://github.com/masanori-satake/QuickLog-Solo/security/code-scanning/3)

In general, the fix is to explicitly set a `permissions` block that limits the `GITHUB_TOKEN` to the minimum rights required. Since this CI workflow only checks out code, computes changed files, installs dependencies, runs linters/tests, and uses caching, it only needs read access to repository contents (for `actions/checkout` and `tj-actions/changed-files`) and does not need write access to any GitHub resources. The best minimal fix is therefore to add `permissions: contents: read` at the workflow root so it applies to all jobs.

Concretely, in `.github/workflows/ci.yml`, add a top‑level `permissions:` section after the `on:` block (or before `jobs:`) specifying `contents: read`. This avoids altering any existing steps or functionality, but constrains the default `GITHUB_TOKEN` for the entire workflow. No additional imports or external methods are needed since this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
