### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Potential fix for [https://github.com/masanori-satake/QuickLog-Solo/security/code-scanning/1](https://github.com/masanori-satake/QuickLog-Solo/security/code-scanning/1)

In general, this problem is fixed by explicitly adding a `permissions` block to the workflow or to each job, granting only the minimum scopes the workflow needs. For a simple deploy workflow that checks out code and then calls a third‑party deployment action using its own token from `secrets`, the minimum is typically `contents: read`. This documents the intended privilege level and prevents accidental escalation if repository/organization defaults change.

The best fix here, without changing existing behavior, is to add a `permissions` block at the job level under `deploy:` in `.github/workflows/deploy.yml`, specifying `contents: read`. None of the existing steps obviously require write access to the repository via `GITHUB_TOKEN`; `actions/checkout` works fine with read‑only contents. Thus we can safely constrain the token. Concretely, in `.github/workflows/deploy.yml`, after `runs-on: ubuntu-latest` (line 11) we add:

```yaml
    permissions:
      contents: read
```

No additional imports, methods, or definitions are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
