### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/animation_eval.yml
+++ b/.github/workflows/animation_eval.yml
@@ -1,5 +1,8 @@
 name: Manual Animation Quality Evaluation
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/masanori-satake/QuickLog-Solo/security/code-scanning/2](https://github.com/masanori-satake/QuickLog-Solo/security/code-scanning/2)

To fix the problem, explicitly set the GITHUB_TOKEN permissions in this workflow to the minimum needed. This workflow only reads repository contents, installs dependencies, and runs tests; it does not modify repository state or interact with issues/PRs. Therefore, specifying `permissions: contents: read` at the workflow or job level is sufficient and preserves existing behavior while enforcing least privilege.

The best fix here is to add a `permissions` block at the root of `.github/workflows/animation_eval.yml`, directly under the `name:` line and before the `on:` key. This will apply to all jobs in the workflow (currently only `evaluate`) without changing any of the steps. No additional imports, methods, or other definitions are needed; we only modify the YAML to include the permissions declaration.

Specifically, in `.github/workflows/animation_eval.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Manual Animation Quality Evaluation`). No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
