### PR TITLE
Replace 'File Sync' icon with 'hard_drive' to emphasize local storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                         <p data-i18n="policy-tracking-desc">アクセス解析やトラッキングコードは一切含みません。あなたの作業を誰も監視しません。</p>
                     </div>
                     <div class="policy-item">
-                        <span class="material-symbols-outlined icon-large">backup</span>
+                        <span class="material-symbols-outlined icon-large">hard_drive</span>
                         <h4>File Sync</h4>
                         <p data-i18n="policy-backup-desc">ローカルフォルダへの自動同期に対応。ブラウザのキャッシュ消去に備えた安心設計です。</p>
                         <p class="policy-hint" data-i18n="policy-backup-hint">※ブラウザ右上のステータス円で同期状況をいつでも確認できます。</p>


### PR DESCRIPTION
The "File Sync" icon on the landing page (index.html) has been updated from a cloud-based icon (`backup`) to a local storage icon (`hard_drive`). This change aligns the visual representation with the application's "Local Only" and "No Tracking" policies, ensuring users understand that their data remains on their local machine.

Key changes:
- Modified `index.html` to replace the `backup` Material Symbol with `hard_drive`.
- Verified the change through Playwright screenshots.
- Confirmed that no other parts of the codebase were using the `backup` icon in an inconsistent manner.

---
*PR created automatically by Jules for task [16520795062259757868](https://jules.google.com/task/16520795062259757868) started by @masanori-satake*