### PR TITLE
Remove legacy branch triggers from GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/quicklog-solo-core
 
 jobs:
   deploy:

--- a/docs/README_ACTIONS.md
+++ b/docs/README_ACTIONS.md
@@ -9,7 +9,7 @@
 | **CI** | `ci.yml` | コードの品質管理、バージョン整合性チェック、テスト実行 | `main`へのPush/PR, 手動 |
 | **OSS Fragment Audit** | `oss_audit.yml` | SCANOSSによる外部コード混入（スニペット盗用）の監査 | `main`へのPush/PR, 手動 |
 | **Animation Quality Evaluation** | `animation_eval.yml` | アニメーションモジュールの品質（描画率、変化率）評価 | `main`へのPR (src/js/animation/**), 手動 |
-| **Deploy to Vercel** | `deploy.yml` | 本番・開発環境への自動デプロイ | `main`, `feat/quicklog-solo-core`へのPush |
+| **Deploy to Vercel** | `deploy.yml` | 本番・開発環境への自動デプロイ | `main`へのPush |
 | **Auto Release** | `release.yml` | バージョンタグ打刻時の自動ビルドおよびGitHub Release作成 | `v*.*.*`タグのPush |
 
 ---
@@ -104,7 +104,7 @@ graph TD
 
 ```mermaid
 graph TD
-    Start([トリガー: main/featへのPush]) --> Checkout[リポジトリのチェックアウト]
+    Start([トリガー: mainへのPush]) --> Checkout[リポジトリのチェックアウト]
     Checkout --> Vercel[Vercelへデプロイ]
     Vercel --> End([完了])
 ```
@@ -137,12 +137,10 @@ graph TD
 | :--- | :---: | :---: | :---: | :---: | :---: |
 | **Push (main)** | ✅ (テストのみ) | ✅ | - | ✅ | - |
 | **Pull Request (main)** | ✅ (+E2E) | ✅ | ✅ (*1) | - | - |
-| **Push (feat/...)** | - | - | - | ✅ (*2) | - |
 | **Tag (v*.*.*)** | - | - | - | - | ✅ |
 | **Manual (Dispatch)** | ✅ | ✅ | ✅ | - | - |
 
 - (*1) `src/js/animation/**` に変更がある場合のみ実行
-- (*2) `feat/quicklog-solo-core` ブランチのみ対象
 
 ### プロセス・フロー概略図
 


### PR DESCRIPTION
This PR removes all references to the legacy `feat/quicklog-solo-core` branch from the GitHub Actions workflows and the associated documentation.

Changes:
- Modified `.github/workflows/deploy.yml` to remove `feat/quicklog-solo-core` from the push triggers.
- Updated `docs/README_ACTIONS.md` to:
    - Remove the branch from the "ワークフロー一覧" table.
    - Update the "Deploy to Vercel" flowchart trigger description.
    - Remove the `Push (feat/...)` row and its footnote from the "トリガー別の動作一覧" table.

These changes ensure that deployments only occur on the `main` branch, adhering to the current development workflow.

---
*PR created automatically by Jules for task [14034313647871728061](https://jules.google.com/task/14034313647871728061) started by @masanori-satake*