### PR TITLE
chore: fix release workflow and sync versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*' # セマンティックバージョニングのタグをトリガーとする
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to release (e.g. v0.26.1)'
+        required: true
+        type: string
 
 jobs:
   release:
@@ -19,6 +25,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install playwright
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -38,5 +47,6 @@ jobs:
       - name: Create GitHub Release and Upload Assets
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
           generate_release_notes: true
           files: releases/*.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",


### PR DESCRIPTION
- Added `workflow_dispatch` to `.github/workflows/release.yml` for manual releases.
- Added `pip install playwright` to fix Python dependency error during build.
- Updated `softprops/action-gh-release` to use the provided tag name.
- Synchronized `package-lock.json` version to 0.26.1.