### PR TITLE
fix: resolve push failure in update-guide-assets workflow

### DIFF
--- a/.github/workflows/update_guide_assets.yml
+++ b/.github/workflows/update_guide_assets.yml
@@ -1,13 +1,6 @@
 name: Update Guide Assets
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/**'
-      - 'scripts/**'
-      - 'guide.html'
-      - 'package.json'
   pull_request:
     branches: [ main ]
     paths:
@@ -19,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-assets:
@@ -60,8 +54,19 @@ jobs:
     - name: Update screenshots
       run: npm run update-guide-images
 
-    - name: Commit and push changes
+    - name: Commit and push changes (PR)
+      if: github.event_name == 'pull_request'
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: "chore: update guide screenshots [skip ci]"
         file_pattern: 'src/assets/guide/*.png'
+
+    - name: Create Pull Request (Manual/Main)
+      if: github.event_name != 'pull_request'
+      uses: peter-evans/create-pull-request@v7
+      with:
+        commit-message: "chore: update guide screenshots [skip ci]"
+        add-paths: 'src/assets/guide/*.png'
+        branch: "chore/update-guide-screenshots"
+        title: "chore: update guide screenshots"
+        body: "Automated update of guide screenshots."


### PR DESCRIPTION
ワークフロー `update-guide-assets` が `main` ブランチへの直接プッシュを試みてリポジトリルール違反で失敗する問題を修正しました。

主な変更点:
- `main` ブランチへの `push` トリガーを削除しました（プルリクエスト経由の変更を強制するため）。
- `pull-requests: write` 権限を追加しました。
- プルリクエストイベント時には引き続き `git-auto-commit-action` を使用して PR ブランチを更新します。
- 手動実行（`workflow_dispatch`）などの PR 以外のイベント時には、`peter-evans/create-pull-request` を使用して新規プルリクエストを作成するように変更しました。

これにより、ブランチ保護ルールを遵守しつつ、自動または手動でのスクリーンショット更新が可能になります。

---
*PR created automatically by Jules for task [10427271913095359105](https://jules.google.com/task/10427271913095359105) started by @masanori-satake*