### PR TITLE
Fix Vercel deployment action version resolution error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v41
+        uses: amondnet/vercel-action@v41.1.4
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
Updated `.github/workflows/deploy.yml` to use `amondnet/vercel-action@v41.1.4` instead of `@v41`.
The tag `v41` does not exist in the upstream repository, causing the "Unable to resolve action" error in GitHub Actions.
Verified that `v41.1.4` is a valid tag in the upstream repository.
Ran local tests to ensure no regressions.

---
*PR created automatically by Jules for task [9830373894855399858](https://jules.google.com/task/9830373894855399858) started by @masanori-satake*