### PR TITLE
fix: remove debug step from audit_oss_compliance.yml

### DIFF
--- a/.github/workflows/audit_oss_compliance.yml
+++ b/.github/workflows/audit_oss_compliance.yml
@@ -36,33 +36,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: List files to be scanned (Debug)
-      run: |
-        echo "Listing files that will be scanned by SCANOSS (not ignored by .scanossignore):"
-        python3 -c "
-import os, fnmatch
-def load_ignore():
-    if not os.path.exists('.scanossignore'): return []
-    with open('.scanossignore') as f:
-        return [l.strip() for l in f if l.strip() and not l.startswith('#')]
-patterns = load_ignore()
-def is_ignored(path):
-    path = path.replace(os.sep, '/')
-    if path.startswith('./'): path = path[2:]
-    for p in patterns:
-        p_match = p.rstrip('/')
-        if fnmatch.fnmatch(path, p) or fnmatch.fnmatch(path, p_match) or fnmatch.fnmatch(os.path.basename(path), p): return True
-        parts = path.split('/')
-        for part in parts:
-            if fnmatch.fnmatch(part, p) or fnmatch.fnmatch(part, p_match): return True
-    return False
-for root, dirs, files in os.walk('.'):
-    dirs[:] = [d for d in dirs if not is_ignored(os.path.join(root, d))]
-    for f in files:
-        p = os.path.join(root, f)
-        if not is_ignored(p): print(f'  {p}')
-        "
-
     - name: Run SCANOSS Code Scan
       id: scanoss-code-scan-step
       uses: scanoss/code-scan-action@v1


### PR DESCRIPTION
Deleted the problematic debug step that was causing a YAML syntax error due to incorrect indentation. This ensures the workflow is valid and can be executed by GitHub Actions.