### PR TITLE
監査: OSSコンプライアンスのクラッシュ修正 (Fix SCANOSS audit crash)

### DIFF
--- a/.scanossignore
+++ b/.scanossignore
@@ -1,34 +1,40 @@
+# SCANOSS Ignore File
+# Documentation: https://github.com/scanoss/scanoss.py
+
 # Dependencies and Build Artifacts
+**/node_modules/
 node_modules/
 releases/
+releases/**
 test-results/
 package-lock.json
 
-# Symlinks (Source is in shared/)
+# Symlinks (Avoid double-scanning shared/ and potential scanner loops)
+# The source is in the root shared/ directory.
+projects/app/shared
 projects/app/shared/
+projects/studio/shared
 projects/studio/shared/
+projects/category-editor/shared
 projects/category-editor/shared/
+projects/web/shared
 projects/web/shared/
 
-# Development and Configuration
+# Internal Tooling and Documentation
 .git/
 .github/
 tests/
 scripts/
 docs/
+# Redundant but added for robustness against different scanner versions
 .git
 .github
 tests
 scripts
 docs
-release_extension_packages.yml
-release_web_deploy.yml
-audit_integrity.yml
-audit_oss_compliance.yml
-test_quality.yml
-test_e2e.yml
-test_animation.yml
-update_guide_screenshots.yml
+
+# Hidden Files and Configuration (Non-production code)
+**/.*
 .*
 .gitignore
 .vercelignore
@@ -40,6 +46,7 @@ eslint.config.js
 jest.config.cjs
 jest.setup.js
 playwright.config.js
+scanoss.json
 *.jsonc
 *.yaml
 *.yml
@@ -61,3 +68,5 @@ playwright.config.js
 *.ttf
 *.eot
 shared/assets/
+shared/assets/**
+**/screenshots/**


### PR DESCRIPTION
SCANOSS監査でのクラッシュ（NameError: name 'unicode' is not defined）を修正するため、`.scanossignore`を改善しました。ディレクトリ構成の変更により追加されたシンボリックリンクや、特定のバイナリファイル、隠しファイルがスキャナーの内部依存関係でエラーを引き起こしていたことが原因です。

主な変更点：
- 再帰的な除外パターンの導入（`**/.*`, `**/node_modules/`）
- シンボリックリンクの堅牢な除外（末尾スラッシュの有無にかかわらず対応）
- `scanoss.json`やテスト成果物（`**/screenshots/**`）の明示的な除外
- メンテナンス性を高めるためのコメント追加

これにより、スキャナーが問題のあるファイルをスキップし、ソースコードのみを適切に検査できるようになります。

---
*PR created automatically by Jules for task [1763561612952967927](https://jules.google.com/task/1763561612952967927) started by @masanori-satake*