### PR TITLE
Fix: Remove redundant push trigger for Guide Screenshots workflow

### DIFF
--- a/.github/workflows/update_guide_screenshots.yml
+++ b/.github/workflows/update_guide_screenshots.yml
@@ -1,13 +1,6 @@
 name: "更新: ガイド用スクリーンショット (Update: Guide Screenshots)"
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'projects/**'
-      - 'scripts/**'
-      - 'projects/web/guide.html'
-      - 'package.json'
   pull_request:
     branches: [ main ]
     paths:


### PR DESCRIPTION
The "Update: Guide Screenshots" workflow was failing when PRs were merged into main. This change removes the push trigger for the main branch, limiting the workflow to pull requests and manual dispatches as requested. This ensures screenshots are updated during the PR process but avoids redundant/failing runs on the main branch.

---
*PR created automatically by Jules for task [10880682203992659477](https://jules.google.com/task/10880682203992659477) started by @masanori-satake*