### PR TITLE
Forbid name property for page-break in category schema

### DIFF
--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -128,7 +128,6 @@ classDiagram
         +String animation
     }
     class PageBreak {
-        +String name
     }
     CategoryItem <|-- RegularCategory
     CategoryItem <|-- PageBreak
@@ -140,10 +139,10 @@ classDiagram
 | `kind` | string | ○ | データ種別 (`"QuickLogSolo/Category"`) |
 | `version` | string | ○ | スキーマバージョン |
 | `type` | string | ○ | カテゴリの種類 (`"category"`, `"page-break"`) |
-| `name` | string | △ | 表示名 (type=category時は必須) |
-| `color` | string | △ | テーマ色 (type=category時は必須) |
-| `tags` | string[] | - | デフォルトのタグ配列 |
-| `animation` | string | - | アニメーション ID (無しは `"none"`) |
+| `name` | string | △ | 表示名 (type=category時のみ。かつ必須) |
+| `color` | string | △ | テーマ色 (type=category時のみ。かつ必須) |
+| `tags` | string[] | - | デフォルトのタグ配列 (type=category時のみ) |
+| `animation` | string | - | アニメーション ID (type=category時のみ。無しは `"none"`) |
 
 ---
 

--- a/docs/schema/category.schema.json
+++ b/docs/schema/category.schema.json
@@ -69,6 +69,7 @@
   },
   "else": {
     "properties": {
+      "name": false,
       "color": false,
       "tags": false,
       "animation": false


### PR DESCRIPTION
Update category schema and documentation to forbid 'name' property when type is 'page-break'. This ensures consistency with other properties like 'color', 'tags', and 'animation' which are already forbidden for page-breaks, as the UI handles their display using localized strings.

---
*PR created automatically by Jules for task [17291479883059191381](https://jules.google.com/task/17291479883059191381) started by @masanori-satake*