### PR TITLE
Vercelへの自動デプロイ・トリガーの修正 (Fix Vercel deployment trigger)

### DIFF
--- a/.github/workflows/release_web_deploy.yml
+++ b/.github/workflows/release_web_deploy.yml
@@ -8,8 +8,12 @@ on:
       - 'projects/**'
       - 'shared/**'
       - 'scripts/**'
+      - 'tests/**'
+      - 'releases/**'
       - 'package.json'
+      - 'package-lock.json'
       - 'vercel.json'
+      - '.github/workflows/release_web_deploy.yml'
   pull_request:
     branches:
       - main
@@ -17,8 +21,12 @@ on:
       - 'projects/**'
       - 'shared/**'
       - 'scripts/**'
+      - 'tests/**'
+      - 'releases/**'
       - 'package.json'
+      - 'package-lock.json'
       - 'vercel.json'
+      - '.github/workflows/release_web_deploy.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
GitHub ActionsによるVercelへの自動デプロイがマージ時に起動しない問題を修正しました。

原因の特定：
`.github/workflows/release_web_deploy.yml` の `paths` フィルタにおいて、ランディングページからリンクされている `releases/` 配下の資産や、依存関係の更新（`package-lock.json`）などが含まれていなかったため、特定の修正においてワークフローがスキップされていました。

修正内容：
- `paths` フィルタに `releases/**`, `package-lock.json`, `tests/**`, およびワークフロー定義ファイル自身を追加しました。
- これにより、アプリケーションの動作や配布資産に関連する変更があった際に、確実に自動デプロイが実行されるようになります。
- `README.md` などのドキュメントのみの更新時にはデプロイをスキップする制限は維持しています。

検証内容：
- `scripts/check_version.py` によるバージョン整合性チェックの合格を確認。
- `npm test` による既存の全テストスイートの合格を確認。
- GitHub Actionsのワークフロー定義の論理的な整合性を確認。

---
*PR created automatically by Jules for task [15334545245863411809](https://jules.google.com/task/15334545245863411809) started by @masanori-satake*