### PR TITLE
fix: GitHub Actions における PR 作成権限エラーの修正とメッセージの日本語化

### DIFF
--- a/.github/workflows/update_guide_screenshots.yml
+++ b/.github/workflows/update_guide_screenshots.yml
@@ -63,15 +63,15 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
-        commit_message: "chore: update guide screenshots"
+        commit_message: "chore: ガイド用スクリーンショットの更新"
         file_pattern: 'shared/assets/guide/*.png'
 
     - name: Create Pull Request (Manual/Main)
       if: github.event_name != 'pull_request'
       uses: peter-evans/create-pull-request@v7.0.5
       with:
-        commit-message: "chore: update guide screenshots"
+        commit-message: "chore: ガイド用スクリーンショットの更新"
         add-paths: 'shared/assets/guide/*.png'
         branch: "chore/update-guide-screenshots"
-        title: "chore: update guide screenshots"
-        body: "Automated update of guide screenshots."
+        title: "chore: ガイド用スクリーンショットの更新"
+        body: "自動生成されたガイド用スクリーンショットの更新です。"


### PR DESCRIPTION
GitHub Actions の `update-assets` ワークフローで発生していた「GitHub Actions is not permitted to create or approve pull requests」エラーに対応しました。

### 変更内容
1. **リポジトリ設定の案内:** エラーの根本原因がリポジトリレベルの権限設定にあることを特定し、ユーザーに設定変更を依頼しました。
2. **ワークフローの日本語化:** `AGENTS.md` の言語規定（日本語最優先）に従い、`.github/workflows/update_guide_screenshots.yml` 内の自動生成メッセージ（コミットメッセージ、PR タイトル、PR 本文）を日本語に翻訳・更新しました。

これにより、Actions による自動更新が正常に動作し、かつプロジェクトの品質基準に合致するようになります。

---
*PR created automatically by Jules for task [8153407108972352297](https://jules.google.com/task/8153407108972352297) started by @masanori-satake*