### PR TITLE
fix: 拡張機能パッケージ公開ワークフローの Playwright 依存関係を修正

### DIFF
--- a/.github/workflows/release_extension_packages.yml
+++ b/.github/workflows/release_extension_packages.yml
@@ -42,6 +42,26 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright Dependencies (if cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Install Python Playwright
+        run: pip install playwright
+
       - name: Build packages
         run: npm run build
 


### PR DESCRIPTION
`release_extension_packages.yml` において、`npm run build` 実行時に必要な Python 版 Playwright の依存関係とブラウザのセットアップ手順を追加しました。

主な変更内容:
- Playwright ブラウザのキャッシュ設定の追加
- Chromium およびシステム依存関係のインストールステップの追加
- Python 版 `playwright` パッケージのインストール (`pip install playwright`) の追加

これにより、ワークフロー内で実行されるアイコン生成スクリプトが正常に動作し、リリース用パッケージの作成が完了するようになります。

Fixes #334

---
*PR created automatically by Jules for task [7200005777928351310](https://jules.google.com/task/7200005777928351310) started by @masanori-satake*