### PR TITLE
アラームエディタの404エラー修正（リダイレクト設定の追加）

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,12 +5,12 @@
     { "source": "/", "destination": "/projects/web/", "permanent": false },
     { "source": "/guide/", "destination": "/projects/web/guide.html", "permanent": false },
     { "source": "/category-editor/", "destination": "/projects/category-editor/", "permanent": false },
-    { "source": "/studio/", "destination": "/projects/studio/", "permanent": false },
     { "source": "/alarm-editor/", "destination": "/projects/alarm-editor/", "permanent": false },
+    { "source": "/studio/", "destination": "/projects/studio/", "permanent": false },
     { "source": "/projects/web/index.html", "destination": "/projects/web/", "permanent": false },
-    { "source": "/projects/studio/index.html", "destination": "/projects/studio/", "permanent": false },
     { "source": "/projects/category-editor/index.html", "destination": "/projects/category-editor/", "permanent": false },
-    { "source": "/projects/alarm-editor/index.html", "destination": "/projects/alarm-editor/", "permanent": false }
+    { "source": "/projects/alarm-editor/index.html", "destination": "/projects/alarm-editor/", "permanent": false },
+    { "source": "/projects/studio/index.html", "destination": "/projects/studio/", "permanent": false }
   ],
   "rewrites": [
     { "source": "/google600c7e741a07d031.html", "destination": "/projects/web/google600c7e741a07d031.html" },

--- a/vercel.json
+++ b/vercel.json
@@ -6,9 +6,11 @@
     { "source": "/guide/", "destination": "/projects/web/guide.html", "permanent": false },
     { "source": "/category-editor/", "destination": "/projects/category-editor/", "permanent": false },
     { "source": "/studio/", "destination": "/projects/studio/", "permanent": false },
+    { "source": "/alarm-editor/", "destination": "/projects/alarm-editor/", "permanent": false },
     { "source": "/projects/web/index.html", "destination": "/projects/web/", "permanent": false },
     { "source": "/projects/studio/index.html", "destination": "/projects/studio/", "permanent": false },
-    { "source": "/projects/category-editor/index.html", "destination": "/projects/category-editor/", "permanent": false }
+    { "source": "/projects/category-editor/index.html", "destination": "/projects/category-editor/", "permanent": false },
+    { "source": "/projects/alarm-editor/index.html", "destination": "/projects/alarm-editor/", "permanent": false }
   ],
   "rewrites": [
     { "source": "/google600c7e741a07d031.html", "destination": "/projects/web/google600c7e741a07d031.html" },


### PR DESCRIPTION
アラームエディタ（/alarm-editor/）へのアクセスが404 NotFoundになっていた原因を特定し、vercel.jsonに適切なリダイレクト設定を追加することで修正しました。

主な変更点：
- vercel.json の redirects 配下に /alarm-editor/ の設定を追加
- /projects/alarm-editor/index.html から /alarm-editor/ へのリダイレクトを追加し、URLの一貫性を確保

---
*PR created automatically by Jules for task [4273717014289204413](https://jules.google.com/task/4273717014289204413) started by @masanori-satake*