### PR TITLE
fix: デプロイワークフローにアラームエディタを含めるように修正

### DIFF
--- a/.github/workflows/release_web_deploy.yml
+++ b/.github/workflows/release_web_deploy.yml
@@ -86,6 +86,7 @@ jobs:
           cp -r projects/web dist_web/projects/
           cp -r projects/app dist_web/projects/
           cp -r projects/category-editor dist_web/projects/
+          cp -r projects/alarm-editor dist_web/projects/
           cp -r projects/studio dist_web/projects/
           cp -r shared dist_web/
           cp -r releases dist_web/

--- a/vercel.json
+++ b/vercel.json
@@ -5,10 +5,12 @@
     { "source": "/", "destination": "/projects/web/", "permanent": false },
     { "source": "/guide/", "destination": "/projects/web/guide.html", "permanent": false },
     { "source": "/category-editor/", "destination": "/projects/category-editor/", "permanent": false },
+    { "source": "/alarm-editor/", "destination": "/projects/alarm-editor/", "permanent": false },
     { "source": "/studio/", "destination": "/projects/studio/", "permanent": false },
     { "source": "/projects/web/index.html", "destination": "/projects/web/", "permanent": false },
-    { "source": "/projects/studio/index.html", "destination": "/projects/studio/", "permanent": false },
-    { "source": "/projects/category-editor/index.html", "destination": "/projects/category-editor/", "permanent": false }
+    { "source": "/projects/category-editor/index.html", "destination": "/projects/category-editor/", "permanent": false },
+    { "source": "/projects/alarm-editor/index.html", "destination": "/projects/alarm-editor/", "permanent": false },
+    { "source": "/projects/studio/index.html", "destination": "/projects/studio/", "permanent": false }
   ],
   "rewrites": [
     { "source": "/google600c7e741a07d031.html", "destination": "/projects/web/google600c7e741a07d031.html" },


### PR DESCRIPTION
vercel.json のリダイレクト設定だけでは、物理的なファイルがデプロイ対象に含まれていなかったため、 release_web_deploy.yml を更新して projects/alarm-editor も dist_web にコピーするようにしました。